### PR TITLE
Added support for global banlist.

### DIFF
--- a/src/main/java/github/pitbox46/itemblacklist/ItemBlacklist.java
+++ b/src/main/java/github/pitbox46/itemblacklist/ItemBlacklist.java
@@ -39,9 +39,20 @@ public class ItemBlacklist {
 
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {
+        // Global banlist
+        Path packFolder = event.getServer(new LevelResource("config"));
+        BANLIST = JsonUtils.initialize(packFolder, "config", "itembanning_blacklist.json");
+        new ArrayList globalBans = JsonUtils.readItemsFromJson(BANLIST);
+        
+        // Per-world banlist
         Path modFolder = event.getServer().getWorldPath(new LevelResource("serverconfig"));
         BANLIST = JsonUtils.initialize(modFolder, "serverconfig", "itemblacklist.json");
-        BANNED_ITEMS = JsonUtils.readItemsFromJson(BANLIST);
+        new ArrayList localBans = JsonUtils.readItemsFromJson(BANLIST);
+
+        // Ensure that there are no duplicates in banlist.
+        Set<String> allBans = new LinkedHashSet<>(globalBans);
+        allBans.addAll(localBans);
+        BANLIST = new ArrayList<>(allBans);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
My attempt at adding support for a global banlist. To allow modpack crators the ability to ban items from their modpack completely. Not only to prevent players from creating items that causes issues (server-lag, crashes, etc), but also to provide modpack creators with more capabilities to fine-tune their players' experience.

Please note that I'm not a java developer, and this is my first attempt at Minecraft modding. Despite trying to find any authorative sources on the proper methods and classes for lines 44 & 45, I was not able to sift through all of the noise. This is untested, and I cannot guarantee that it'll work. Hopefully, if there's anything wrong, it'll be easy for those of you who know what you're doing to fix my fumbling attempts. :)